### PR TITLE
Make Confidence/Relevence threshold OR

### DIFF
--- a/inc/extract.php
+++ b/inc/extract.php
@@ -119,7 +119,7 @@ function extract_entities( WP_Post $post ): array {
 			// Ensure we meet minimum confidence and relevance scores.
 			if (
 				( $entity['confidenceScore'] ?? 0 ) < (float) get_option( Admin\OPTION_MIN_CONFIDENCE, 0 )
-				&& ( $entity['relevanceScore'] ?? 0 ) < (float) get_option( Admin\OPTION_MIN_RELEVANCE, 0 )
+				|| ( $entity['relevanceScore'] ?? 0 ) < (float) get_option( Admin\OPTION_MIN_RELEVANCE, 0 )
 			) {
 				Utils\debug_log( sprintf( '❌ Minimum score not met: %s', $entity['entityId'] ) );
 


### PR DESCRIPTION
I've set some thresholds to filter out the lowest value results as follows. 

* **Confidence** 1 
* **Relevance** 0.1

However after analysing some content, I'm seeing entities with a relevance score of 0 - I would expect this to have been skipped. 

Looks like the check is to only discard if BOTH the confidence and relevance checks fail, but I think more logical would be skip if either/or fail.