### PR TITLE
Set default export format to CSV

### DIFF
--- a/inc/export.php
+++ b/inc/export.php
@@ -60,7 +60,7 @@ function get_items( WP_REST_Request $request ) {
 	header( 'X-Accel-Buffering: no' );
 
 	// Check accept header for format.
-	$format = $request->get_param( 'format' );
+	$format = $request->get_param( 'format' ) ?? 'csv';
 
 	// Set content type header.
 	if ( $format === 'json' ) {


### PR DESCRIPTION
Closing https://github.com/humanmade/entity-base/pull/4 in favour of this. 

Problem turned out to be simple... unless you explicitly pass format, it doesn't actually output anything! However a lot of the code assumes that if it is not JSON, it's CSV so lets default to that. 