### PR TITLE
Add connected post count column. to entity list table

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,17 @@ When a post is analysed, the extracted entities are saved to the post's meta dat
 - `_entity_rel_{entity_slug}`: Relevance score for each entity.
 - `_entities`: Array of all extracted entites and associated data from TextRazor.
 
-The posts associated with an entity can be queried using a meta key EXISTS query.
+The posts associated with an entity can be queried using the function `EntityBase\Utils\query_connected_posts`
 
 Example code:
 
 ```php
-$connected_posts = new WP_Query( [
-	'post_type' => 'any',
-	'post_status' => 'publish',
-	'meta_key' => mb_strcut( '_entity_' . $entity->post_name, 0, 256 ),
-	'meta_compare' => 'EXISTS',
-] );
+$connected_posts = EntityBase\Utils\query_connected_posts( $entity_post );
 ```
 
 When an entity is deleted, the confidence and relevence scores attached to posts are also deleted.
+
+The connected post count is stored in the comment_count column so you can query and order based on this value in a performant way.
 
 ## Exporting entities
 

--- a/README.md
+++ b/README.md
@@ -52,17 +52,32 @@ When a post is analysed, the extracted entities are saved to the post's meta dat
 - `_entity_rel_{entity_slug}`: Relevance score for each entity.
 - `_entities`: Array of all extracted entites and associated data from TextRazor.
 
-The posts associated with an entity can be queried using the function `EntityBase\Utils\query_connected_posts`
+The posts associated with an entity can be queried using a meta key EXISTS query. Or by using the utility function `EntityBase\Utils\query_connected_posts`.
 
 Example code:
 
 ```php
 $connected_posts = EntityBase\Utils\query_connected_posts( $entity_post );
+
+// Or
+
+$connected_posts = new WP_Query( [
+	'post_type' => 'any',
+	'post_status' => 'publish',
+	'meta_key' => mb_strcut( '_entity_' . $entity->post_name, 0, 256 ),
+	'meta_compare' => 'EXISTS',
+] );
 ```
 
 When an entity is deleted, the confidence and relevence scores attached to posts are also deleted.
 
-The connected post count is stored in the comment_count column so you can query and order based on this value in a performant way.
+The connected post count is stored in the comment_count column so you can query and order entities based on this value in a performant way.
+
+To query for all entities attached to a post, you can use the utility function `get_entities_for_post` which will return the entities ordered by relevance score.
+
+```
+$entities = EntityBase\Utils\get_entities_for_post( WP_Post $post );
+```
 
 ## Exporting entities
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ $connected_posts = new WP_Query( [
 ] );
 ```
 
-When an entity is deleted, the confidence and relevence scores attached to posts are also deleted.
+When an entity is deleted, the confidence and relevance scores attached to posts are also deleted.
 
-The connected post count is stored in the comment_count column so you can query and order entities based on this value in a performant way.
+The connected post count is stored in the `comment_count` column of the entity so that you can query and order entities based on this value in a performant way.
 
 To query for all entities attached to a post, you can use the utility function `get_entities_for_post` which will return the entities ordered by relevance score.
 
-```
+```php
 $entities = EntityBase\Utils\get_entities_for_post( WP_Post $post );
 ```
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -154,6 +154,8 @@ function make_connected_posts_column_sortable( array $columns ): array {
 /**
  * Sort the entities by the number of connected posts.
  *
+ * We're storing this data in the core WP comment count column for performance reasons.
+ *
  * @param \WP_Query $query The current query.
  */
 function sort_by_connected_posts( \WP_Query $query ): void {
@@ -168,6 +170,9 @@ function sort_by_connected_posts( \WP_Query $query ): void {
 
 /**
  * Filters comment count for entity post types and store connected post count.
+ *
+ * We're abusing the comment count column for this post type for performance reasons.
+ * This means we can easily order by connected post count without a meta query.
  *
  * @param int|null $new_count The new comment count.
  * @param int $old_count The old comment count.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -136,7 +136,6 @@ function add_connected_posts_column( array $columns ): array {
 function render_connected_posts_column( string $column, int $post_id ): void {
 	if ( 'connected_posts' === $column ) {
 		$entity_post = get_post( $post_id );
-
 		echo absint( $entity_post->comment_count );
 	}
 }
@@ -163,7 +162,6 @@ function sort_by_connected_posts( \WP_Query $query ): void {
 	}
 
 	if ( 'connected_posts' === $query->get( 'orderby' ) ) {
-		// $query->set( 'meta_key', '_connected_posts_count' );
 		$query->set( 'orderby', 'comment_count' );
 	}
 }

--- a/inc/single.php
+++ b/inc/single.php
@@ -5,12 +5,15 @@
 
 namespace EntityBase\Single;
 
+use EntityBase;
 use EntityBase\Extract;
 use EntityBase\Utils;
 use WP_Post;
 
 function setup(): void {
 	add_action( 'save_post', __NAMESPACE__ . '\\analyse_post', 10, 3 );
+	add_action( 'transition_post_status', __NAMESPACE__ . '\\update_connected_entities_count_on_transition_post_status', 10, 4 );
+	add_action( 'before_delete_post', __NAMESPACE__ . '\\update_connected_entities_count_on_before_delete', 10, 4 );
 }
 
 /**
@@ -37,4 +40,53 @@ function analyse_post( int $post_id, WP_Post $post, bool $update ): void {
 
 	// Avoid overloading memory.
 	wp_cache_flush_runtime();
+}
+
+/**
+ * Update the connected entities count when a post status changes.
+ *
+ * Update if publishing, or unpublishing a post.
+ *
+ * @param string $new_status The new post status.
+ * @param string $old_status The old post status.
+ * @param WP_Post $post The post object.
+ */
+function update_connected_entities_count_on_transition_post_status( string $new_status, string $old_status, WP_Post $post ): void {
+	if (
+		( 'publish' === $new_status && 'publish' !== $old_status )
+		|| ( 'publish' === $old_status && 'publish' !== $new_status )
+	) {
+		foreach ( Utils\get_entities_for_post( $post ) as $entity ) {
+			EntityBase\update_connected_posts_count( $entity );
+		}
+	}
+}
+
+/**
+ * Update the connected entities count when a post is deleted.
+ *
+ * @param int $post_id The ID of the post being deleted.
+ */
+function update_connected_entities_count_on_before_delete( int $post_id ): void {
+	$post = get_post( $post_id );
+
+	if ( ! $post ) {
+		return;
+	}
+
+	$entities = Utils\get_entities_for_post( $post );
+
+	if ( empty( $entities ) ) {
+		return;
+	}
+
+	add_action( 'deleted_post', function( $delete_post_id ) use ( $post_id, $entities ) {
+		if ( $post_id !== absint( $delete_post_id ) || empty( $entities ) ) {
+			return;
+		}
+
+		foreach ( $entities as $entity ) {
+			EntityBase\update_connected_posts_count( $entity );
+		}
+	} );
 }

--- a/inc/single.php
+++ b/inc/single.php
@@ -13,7 +13,13 @@ function setup(): void {
 	add_action( 'save_post', __NAMESPACE__ . '\\analyse_post', 10, 3 );
 }
 
-
+/**
+ * Analyse the post and extract entities on save.
+ *
+ * @param int $post_id The ID of the post being saved.
+ * @param WP_Post $post The post object.
+ * @param bool $update Whether this is an existing post being updated or not.
+ */
 function analyse_post( int $post_id, WP_Post $post, bool $update ): void {
 	$allowed_post_types = apply_filters( 'entitybase_allowed_post_types', [ 'post' ] );
 

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -79,9 +79,7 @@ function maybe_create_entity( array $entity ): void {
  * @param WP_Post $entity_post The entity post object.
  */
 function update_connected_posts_count( WP_Post $entity_post ): void {
-	delete_post_meta( $entity_post->ID, '_connected_posts_count' );
-	$connected_posts_count = get_connected_posts_count( $entity_post );
-	update_post_meta( $entity_post->ID, '_connected_posts_count', $connected_posts_count );
+	wp_update_comment_count( $entity_post->ID, true );
 }
 
 /**

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -2,6 +2,7 @@
 
 namespace EntityBase\Utils;
 
+use EntityBase;
 use EntityBase\Admin;
 use TextRazor;
 use TextRazorSettings;
@@ -34,8 +35,7 @@ function maybe_create_entity( array $entity ): void {
 	$existing_entity_post = get_page_by_path( $slug, OBJECT, 'entity' );
 
 	if ( ! empty( $existing_entity_post ) ) {
-		// Update the saved connected posts count.
-		update_connected_posts_count( $existing_entity_post );
+		EntityBase\update_connected_posts_count( $existing_entity_post );
 		return;
 	}
 
@@ -63,7 +63,7 @@ function maybe_create_entity( array $entity ): void {
 	}
 
 	// Update the saved connected posts count.
-	update_connected_posts_count( get_post( $entity_post_id ) );
+	EntityBase\update_connected_posts_count( get_post( $entity_post_id ) );
 
 	/**
 	 * Fires once an entity has been created.
@@ -71,17 +71,6 @@ function maybe_create_entity( array $entity ): void {
 	 * @param int $entity_post_id The ID of the entity post.
 	 */
 	do_action( 'entitybase_entity_created', $entity_post_id );
-}
-
-/**
- * Update the count of connected posts for an entity.
- *
- * This is stored in the WP core comment count column for performance reasons.
- *
- * @param WP_Post $entity_post The entity post object.
- */
-function update_connected_posts_count( WP_Post $entity_post ): void {
-	wp_update_comment_count( $entity_post->ID, true );
 }
 
 /**
@@ -167,24 +156,6 @@ function get_dbpedia_blocklist(): array {
  */
 function get_freebase_blocklist(): array {
 	return array_filter( explode( "\r\n", get_option( Admin\OPTION_FREEBASE_BLOCKLIST, '' ) ) );
-}
-
-
-/**
- * Get the number of connected posts for a given entity.
- *
- * @param WP_Post $entity_post The entity post object.
- * @return int The number of connected posts.
- */
-function get_connected_posts_count( WP_Post $entity_post ): int {
-	$connected_posts_count = get_post_meta( $entity_post->ID, '_connected_posts_count', true );
-
-	if ( ! empty( $connected_posts_count ) ) {
-		return $connected_posts_count;
-	}
-
-	$connected_posts = query_connected_posts( $entity_post );
-	return (int) $connected_posts->found_posts;
 }
 
 /**

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -34,7 +34,7 @@ function maybe_create_entity( array $entity ): void {
 	$existing_entity_post = get_page_by_path( $slug, OBJECT, 'entity' );
 
 	if ( ! empty( $existing_entity_post ) ) {
-		// Update the connected posts count.
+		// Update the saved connected posts count.
 		update_connected_posts_count( $existing_entity_post );
 		return;
 	}
@@ -62,7 +62,7 @@ function maybe_create_entity( array $entity ): void {
 		wp_set_post_terms( $entity_post_id, $entity['freebaseTypes'], 'entity_freebase_type', false );
 	}
 
-	// Update the connected posts count.
+	// Update the saved connected posts count.
 	update_connected_posts_count( get_post( $entity_post_id ) );
 
 	/**
@@ -75,6 +75,8 @@ function maybe_create_entity( array $entity ): void {
 
 /**
  * Update the count of connected posts for an entity.
+ *
+ * This is stored in the WP core comment count column for performance reasons.
  *
  * @param WP_Post $entity_post The entity post object.
  */


### PR DESCRIPTION
I think it would improve the usability of this tool if we could easily see how many posts are connected to each entity, helping identify the popular ones. 

~Opening as draft, as I wonder if we could make use of the comment count column for this as a meta query is not ideal.~