### PR TITLE
Connected entities meta box

### DIFF
--- a/inc/admin-single.php
+++ b/inc/admin-single.php
@@ -101,6 +101,10 @@ function admin_css(): void {
 	border-bottom: none;
 }
 
+#entities_meta_box th {
+	font-weight: bold;
+}
+
 #entities_meta_box th,
 #entities_meta_box td {
 	padding: 8px;

--- a/inc/admin-single.php
+++ b/inc/admin-single.php
@@ -68,7 +68,7 @@ function render_entities_meta_box( WP_Post $post ): void {
 		 * @param string $edit_link The edit link for the entity.
 		 * @param WP_Post $entity The entity object.
 		 */
-		$edit_link = apply_filters( 'hm.entity-base.meta_box_entity_edit_link', get_edit_post_link( $entity->ID ), $entity );
+		$edit_link = apply_filters( 'entitybase_entities_meta_box_edit_link', get_edit_post_link( $entity->ID ), $entity );
 
 		echo '<tr>';
 		echo '<td><a href="' . esc_url( $edit_link ) . '">' . esc_html( $entity->post_title ) . '</a></td>';

--- a/inc/admin-single.php
+++ b/inc/admin-single.php
@@ -21,11 +21,13 @@ function setup(): void {
  * Add the entities meta box to the post edit screen.
  */
 function add_entities_meta_box(): void {
+	$allowed_post_types = apply_filters( 'entitybase_allowed_post_types', [ 'post' ] );
+
 	add_meta_box(
 		'entities_meta_box',
 		__( 'Entities', 'entity-base' ),
 		__NAMESPACE__ . '\\render_entities_meta_box',
-		'post',
+		$allowed_post_types,
 		'side',
 		'default'
 	);

--- a/inc/admin-single.php
+++ b/inc/admin-single.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Admin Entities Panel
+ *
+ * Display connected entities in the post edit screen.
+ *
+ * @package EntityBase
+ */
+
+namespace EntityBase\AdminSingle;
+
+use WP_Post;
+use function EntityBase\Utils\get_entities_for_post;
+
+function setup(): void {
+	add_action( 'add_meta_boxes', __NAMESPACE__ . '\\add_entities_meta_box' );
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\admin_css' );
+}
+
+/**
+ * Add the entities meta box to the post edit screen.
+ */
+function add_entities_meta_box(): void {
+	add_meta_box(
+		'entities_meta_box',
+		__( 'Entities', 'entity-base' ),
+		__NAMESPACE__ . '\\render_entities_meta_box',
+		'post',
+		'side',
+		'default'
+	);
+
+	// The comments meta box is shown when comment count is greater than 0.
+	// As we're using this field to store connected entity count, force hide it.
+	remove_meta_box( 'commentsdiv', 'entity', 'normal' );
+}
+
+/**
+ * Render the entities meta box.
+ *
+ * @param WP_Post $post The current post object.
+ */
+function render_entities_meta_box( WP_Post $post ): void {
+	$entities = get_entities_for_post( $post );
+
+	if ( empty( $entities ) ) {
+		echo '<p>' . esc_html__( 'No entities found.', 'entity-base' ) . '</p>';
+		return;
+	}
+
+	echo '<div class="entities-table-wrapper">';
+	echo '<table class="widefat">';
+	echo '<thead><tr>';
+	echo '<th>' . esc_html__( 'Entity', 'entity-base' ) . '</th>';
+	echo '<th style="text-align: right;">' . esc_html__( 'Relevance', 'entity-base' ) . '</th>';
+	echo '</tr></thead>';
+	echo '<tbody>';
+
+	foreach ( $entities as $entity ) {
+
+		/**
+		 * Filter the edit link for the entity in the meta box.
+		 *
+		 * This filter allows modification of the edit link for the entity displayed in the meta box.
+		 *
+		 * @param string $edit_link The edit link for the entity.
+		 * @param WP_Post $entity The entity object.
+		 */
+		$edit_link = apply_filters( 'hm.entity-base.meta_box_entity_edit_link', get_edit_post_link( $entity->ID ), $entity );
+
+		echo '<tr>';
+		echo '<td><a href="' . esc_url( $edit_link ) . '">' . esc_html( $entity->post_title ) . '</a></td>';
+		$relevance = number_format( (float) get_post_meta( $post->ID, '_entity_rel_' . $entity->post_name, true ), 2, '.', '' );
+		echo '<td style="text-align: right;">' . esc_html( $relevance ) . '</td>';
+		echo '</tr>';
+	}
+
+	echo '</tbody>';
+	echo '</table>';
+	echo '</div>';
+}
+
+/**
+ * Add Admin CSS.
+ */
+function admin_css(): void {
+	ob_start();
+	?>
+.entities-table-wrapper {
+	overflow-x: auto;
+	border: 1px solid #ddd;
+}
+
+#entities_meta_box table {
+	width: 100%;
+	border-collapse: collapse;
+	margin: -1px 0 0 -1px;
+	border-right: none;
+	border-bottom: none;
+}
+
+#entities_meta_box th,
+#entities_meta_box td {
+	padding: 8px;
+	border: 1px solid #ddd;
+}
+
+#entities_meta_box th:last-child,
+#entities_meta_box td:last-child {
+	border-right: none;
+}
+
+#entities_meta_box tr:last-child td {
+	border-bottom: none;
+}
+
+#entities_meta_box th {
+	background-color: #f9f9f9;
+}
+	<?php
+
+	$admin_css = trim( ob_get_clean() );
+	wp_add_inline_style( 'wp-admin', $admin_css );
+}

--- a/inc/admin-single.php
+++ b/inc/admin-single.php
@@ -72,8 +72,8 @@ function render_entities_meta_box( WP_Post $post ): void {
 
 		echo '<tr>';
 		echo '<td><a href="' . esc_url( $edit_link ) . '">' . esc_html( $entity->post_title ) . '</a></td>';
-		$relevance = number_format( (float) get_post_meta( $post->ID, '_entity_rel_' . $entity->post_name, true ), 2, '.', '' );
-		echo '<td style="text-align: right;">' . esc_html( $relevance ) . '</td>';
+		$relevance = (float) get_post_meta( $post->ID, '_entity_rel_' . $entity->post_name, true ) * 100;
+		echo '<td style="text-align: right;">' . esc_html( number_format( $relevance, 0 ) ) . '%</td>';
 		echo '</tr>';
 	}
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -59,7 +59,9 @@ function settings_init() {
 	register_setting( 'entitybase_settings', OPTION_DBPEDIA_BLOCKLIST );
 	register_setting( 'entitybase_settings', OPTION_FREEBASE_BLOCKLIST );
 	register_setting( 'entitybase_settings', OPTION_MIN_CONFIDENCE );
-	register_setting( 'entitybase_settings', OPTION_MIN_RELEVANCE );
+	register_setting( 'entitybase_settings', OPTION_MIN_RELEVANCE, [
+		'sanitize_callback' => __NAMESPACE__ . '\\sanitize_percentage',
+	] );
 
 	add_settings_section(
 		'entitybase_settings_section',
@@ -220,10 +222,21 @@ function minimum_confidence_callback() {
 
 // Callback function for the minimum relevance field.
 function minimum_relevance_callback() {
+	$relevance = floatval( get_option( OPTION_MIN_RELEVANCE, 0 ) ) * 100;
 	printf(
-		'<input type="number" min="0" max="1" step="0.01" name="%s" value="%s" />',
+		'<input type="number" min="0" max="100" step="0.1" name="%s" value="%s" />&percnt;',
 		esc_attr( OPTION_MIN_RELEVANCE ),
-		esc_attr( get_option( OPTION_MIN_RELEVANCE, 0 ) )
+		esc_attr( $relevance )
 	);
-	printf( '<p class="description">%s</p>', esc_html__( 'Between 0 and 1', 'entitybase' ) );
+	printf( '<p class="description">%s</p>', esc_html__( 'Enter a percentage between 0 and 100.', 'entitybase' ) );
+}
+
+/**
+ * Sanitize a percentage.
+ *
+ * @param mixed $value The value to sanitize.
+ * @return float The sanitized value.
+ */
+function sanitize_percentage( $value ): float {
+	return max( 0, min( 1, floatval( $value ) / 100 ) );
 }

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -201,8 +201,8 @@ function get_entities_for_post( WP_Post $post, array $query_args = [] ): array {
 	}
 
 	// Order entities by relevance
-	usort( $entity_meta_keys, function( $a, $b ) use ( $meta ){
-		return $meta[ $a ] <=> $meta[ $b ];
+	usort( $entity_meta_keys, function( $a, $b ) use ( $meta ) {
+		return floatval( $meta[ $b ][0] ) <=> floatval( $meta[ $a ][0] );
 	} );
 
 	// Extract slugs from meta keys.

--- a/plugin.php
+++ b/plugin.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/inc/utils.php';
 require_once __DIR__ . '/inc/namespace.php';
 
 require_once __DIR__ . '/inc/admin.php';
+require_once __DIR__ . '/inc/admin-single.php';
 require_once __DIR__ . '/inc/cleanup.php';
 require_once __DIR__ . '/inc/cli.php';
 require_once __DIR__ . '/inc/export.php';
@@ -25,6 +26,7 @@ require_once __DIR__ . '/inc/single.php';
 
 setup();
 Admin\setup();
+AdminSingle\setup();
 Cleanup\setup();
 CLI\setup();
 Export\setup();


### PR DESCRIPTION
I'd like to surface the entities identified for a post within the admin. This PR does the following

* Add a meta box to supported post types
* Display all entities and their relevance scores. 
* Link to the edit screen of that entity
* Link is filterable

<img width="324" alt="image" src="https://github.com/user-attachments/assets/ad3c63d9-198a-4b24-8bfe-52dc634c716d">
